### PR TITLE
Added support for adding user authorities based on bitbucket team/role

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ Second, you need to configure your Jenkins.
 8. Input your Consumer Secret to **Client Secret**.
 9. Click **Save** button.
 
+### Bitbucket Team access Support
+Based on the teams that user has access to, this plugin automatically creates groups of the form
+
+_team::role_
+
+Supported roles are `admin`, `contributor` and `member`
+
+Examples
+```
+team1::admin
+team2::contributor
+team3::member
+```
+
+These group names can be used in Jenkins *Matrix-based security* to give fine grained access control based on the users team access in Bitbucket.
 
 Via Groovy script
 -----------------------------------

--- a/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins;
 
-import hudson.security.SecurityRealm;
-
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
@@ -14,6 +14,7 @@ import org.acegisecurity.userdetails.UserDetailsService;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.api.BitbucketApiService;
+import org.jenkinsci.plugins.api.BitbucketGroup;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
@@ -49,7 +50,7 @@ public class BitbucketSecurityRealm extends SecurityRealm {
     private String clientSecret;
 
     @DataBoundConstructor
-    public BitbucketSecurityRealm(String clientID, String clientSecret) {
+    public BitbucketSecurityRealm(String clientID, String clientSecret, String team) {
         super();
         this.clientID = Util.fixEmptyAndTrim(clientID);
         this.clientSecret = Util.fixEmptyAndTrim(clientSecret);
@@ -181,7 +182,14 @@ public class BitbucketSecurityRealm extends SecurityRealm {
 
     @Override
     public GroupDetails loadGroupByGroupname(String groupName) {
-        throw new UsernameNotFoundException("groups not supported");
+        if(groupName.contains("::"))
+        {
+            return new BitbucketGroup(groupName);
+        }
+        else
+        {
+            throw new UsernameNotFoundException("Group does not exist:" + groupName);
+        }
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/api/BitBucketTeamsResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitBucketTeamsResponse.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.api;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents Bitbuckets team api response
+ *
+ * https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams
+ */
+public class BitBucketTeamsResponse
+{
+    @SerializedName("next")
+    private String next;
+
+    @SerializedName("values")
+    private List<Teams> teamsList;
+
+    public List<Teams> getTeamsList()
+    {
+        return teamsList;
+    }
+
+    public void setTeamsList(List<Teams> teamsList)
+    {
+        this.teamsList = teamsList;
+    }
+
+    public String getNext()
+    {
+        return next;
+    }
+
+    public void setNext(String next)
+    {
+        this.next = next;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketGroup.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.api;
+
+import hudson.security.GroupDetails;
+
+public class BitbucketGroup extends GroupDetails
+{
+    private String name;
+
+    public BitbucketGroup(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
@@ -1,12 +1,14 @@
 package org.jenkinsci.plugins.api;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.gson.annotations.SerializedName;
-
-import hudson.security.SecurityRealm;
 
 public class BitbucketUser implements UserDetails {
 
@@ -25,13 +27,21 @@ public class BitbucketUser implements UserDetails {
     @SerializedName("resource_uri")
     public String resourceUri;
 
+    List<GrantedAuthority> grantedAuthorties = new ArrayList<GrantedAuthority>();
+
     public BitbucketUser() {
         super();
     }
 
     @Override
     public GrantedAuthority[] getAuthorities() {
-        return new GrantedAuthority[] { SecurityRealm.AUTHENTICATED_AUTHORITY };
+
+        return grantedAuthorties.toArray(new GrantedAuthority[grantedAuthorties.size()]);
+    }
+
+    public void addAuthority(String role)
+    {
+        grantedAuthorties.add(new GrantedAuthorityImpl(role));
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketUserPrivileges.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketUserPrivileges.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.api;
+
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+public class BitbucketUserPrivileges {
+
+    @SerializedName("teams")
+    Map<String, String> teams;
+
+    public Map<String, String> getTeams()
+    {
+        return teams;
+    }
+
+    public void setTeams(Map<String, String> teams)
+    {
+        this.teams = teams;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/api/Teams.java
+++ b/src/main/java/org/jenkinsci/plugins/api/Teams.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.api;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Teams
+{
+    @SerializedName("username")
+    String username;
+
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("display_name")
+    String displayName;
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername(String username)
+    {
+        this.username = username;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String type)
+    {
+        this.type = type;
+    }
+
+    public String getDisplayName()
+    {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName)
+    {
+        this.displayName = displayName;
+    }
+}


### PR DESCRIPTION
This allows users to setup matrix security based on user's access to a team.