### PR TITLE
feat(core) use ouath 2 & v2 api endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 target
 work
 .classpath
+.factorypath
 .project
 .settings
 *.iml
 .idea
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scribe</groupId>
-			<artifactId>scribe</artifactId>
-			<version>1.3.3</version>
+			<groupId>com.github.scribejava</groupId>
+			<artifactId>scribejava-core</artifactId>
+			<version>6.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
@@ -1,20 +1,23 @@
 package org.jenkinsci.plugins;
 
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.api.BitbucketApiService;
 import org.jenkinsci.plugins.api.BitbucketUser;
-import org.scribe.model.Token;
 
 public class BitbucketAuthenticationToken extends AbstractAuthenticationToken {
 
     private static final long serialVersionUID = -7826610577724673531L;
 
-    private Token accessToken;
+    private OAuth2AccessToken accessToken;
     private BitbucketUser bitbucketUser;
 
-    public BitbucketAuthenticationToken(Token accessToken, String apiKey, String apiSecret) {
+    public BitbucketAuthenticationToken(OAuth2AccessToken accessToken, String apiKey, String apiSecret) {
+        super(null);
+
         this.accessToken = accessToken;
         this.bitbucketUser = new BitbucketApiService(apiKey, apiSecret).getUserByToken(accessToken);
 
@@ -35,7 +38,7 @@ public class BitbucketAuthenticationToken extends AbstractAuthenticationToken {
     /**
      * @return the accessToken
      */
-    public Token getAccessToken() {
+    public OAuth2AccessToken getAccessToken() {
         return accessToken;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApi.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApi.java
@@ -1,23 +1,29 @@
 package org.jenkinsci.plugins.api;
 
-import org.scribe.builder.api.DefaultApi10a;
-import org.scribe.model.Token;
+import com.github.scribejava.core.builder.api.DefaultApi20;
 
-public class BitbucketApi extends DefaultApi10a {
-    private static final String OAUTH_ENDPOINT = "https://bitbucket.org/api/1.0/oauth/";
+public class BitbucketApi extends DefaultApi20 {
+    private static final String TOKEN_URL = "https://bitbucket.org/site/oauth2/access_token";
+    private static final String AUTHORIZE_URL = "https://bitbucket.org/site/oauth2/authorize";
+
+    protected BitbucketApi() {
+    }
+
+    private static class InstanceHolder {
+        private static final BitbucketApi INSTANCE = new BitbucketApi();
+    }
+
+    public static BitbucketApi instance() {
+        return InstanceHolder.INSTANCE;
+    }
 
     @Override
     public String getAccessTokenEndpoint() {
-        return OAUTH_ENDPOINT + "access_token";
+      return TOKEN_URL;
     }
 
     @Override
-    public String getAuthorizationUrl(Token oauthToken) {
-        return OAUTH_ENDPOINT + "authenticate?oauth_token=" + oauthToken.getToken();
-    }
-
-    @Override
-    public String getRequestTokenEndpoint() {
-        return OAUTH_ENDPOINT + "request_token";
+    protected String getAuthorizationBaseUrl() {
+        return AUTHORIZE_URL;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
@@ -8,24 +8,9 @@ import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.userdetails.UserDetails;
 import org.apache.commons.lang.StringUtils;
 
-import com.google.gson.annotations.SerializedName;
-
 public class BitbucketUser implements UserDetails {
 
-    public class BitbucketUserResponce {
-        public BitbucketUser user;
-    }
-
     public String username = StringUtils.EMPTY;
-    @SerializedName("first_name")
-    public String firstName;
-    @SerializedName("last_name")
-    public String lastName;
-    @SerializedName("is_team")
-    public boolean isTeam;
-    public String avatar;
-    @SerializedName("resource_uri")
-    public String resourceUri;
 
     List<GrantedAuthority> grantedAuthorties = new ArrayList<GrantedAuthority>();
 
@@ -73,5 +58,4 @@ public class BitbucketUser implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
-
 }


### PR DESCRIPTION
actually all bitbucket 1.0 APIs will be removed from the REST API permanently on 31 December 2018. (https://confluence.atlassian.com/bitbucket/version-1-423626337.html)

so refactoring is necessary.